### PR TITLE
support parallel routes

### DIFF
--- a/.changeset/light-cougars-provide.md
+++ b/.changeset/light-cougars-provide.md
@@ -1,0 +1,5 @@
+---
+"@nirtamir2/next-static-paths": minor
+---
+
+Support parallel routes

--- a/packages/next-static-paths/cli/pageFilePathToPathname.ts
+++ b/packages/next-static-paths/cli/pageFilePathToPathname.ts
@@ -27,5 +27,6 @@ export function appFilePathToPathname(
       .replace(/\/+$/, "")
       .replace(/^$/, "/")
       .replace(/\[\[(.*?)]]/g, "[$1]")
+      .replace(/\/@[^/]+/, "")
   );
 }


### PR DESCRIPTION
`/@whatever/` segments should not be part of the generated URLs.

https://nextjs.org/docs/app/building-your-application/routing/parallel-routes