### PR TITLE
allow next 14

### DIFF
--- a/packages/next-static-paths/package.json
+++ b/packages/next-static-paths/package.json
@@ -47,7 +47,7 @@
     "vitest": "^0.32.2"
   },
   "peerDependencies": {
-    "next": "^13.4.6",
+    "next": "^13.4.6 || ^14.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }


### PR DESCRIPTION
just silences peer dep errors because next 14 doesn't match the allowed versions.